### PR TITLE
secilc: Ignore empty mappings

### DIFF
--- a/secilc/secilc.c
+++ b/secilc/secilc.c
@@ -270,6 +270,12 @@ int main(int argc, char *argv[])
 
 		buffer = malloc(file_size);
 		rc = fread(buffer, file_size, 1, file);
+		if (rc == 0) {
+			fprintf(stdout, "Ignoring empty file: %s\n", argv[i]);
+			free(buffer);
+			buffer = NULL;
+			continue;
+		}
 		if (rc != 1) {
 			fprintf(stderr, "Failure reading file: %s\n", argv[i]);
 			rc = SEPOL_ERR;


### PR DESCRIPTION
- When compiling SELinux policy, secilc may falsely fail.
- A great example is the mappings created for system_ext on Android 11.
  When attempting to boot a compiled A11 system image with a v29 vendor
  image, loading of precompiled policy will fail since:
    /vendor/etc/selinux/precompiled_sepolicy.system_ext_sepolicy_and_mapping.sha256
  is missing. init will try to compile sepolicy and will see the
  following files are present:
    /system_ext/etc/selinux/mapping/26.0.cil
    /system_ext/etc/selinux/mapping/27.0.cil
    /system_ext/etc/selinux/mapping/28.0.cil
    /system_ext/etc/selinux/mapping/29.0.cil
    /system_ext/etc/selinux/mapping/30.0.cil
  Here, only 30.0.cil is not empty and valid, breaking bootup with the
  following message trying to load the empty 29.0 mapping:
    init: /system/bin/secilc: Failure reading file: /system_ext/etc/selinux/mapping/29.0.cil
    init: /system/bin/secilc exited with status 255
- Instead, we can safely ignore all files passed to secilc that are
  empty and continue populating db with valid files, to be compatible
  with older vendors.

Test: Compile and boot system.img with prebuilt v29 vendor.img on begonia
Change-Id: I2f22914803b0ba34a8f92de759ba8ee44bb54b9b
Signed-off-by: Ayush Dubey <ayushdubey70@gmail.com>